### PR TITLE
restrict to only drupal/* packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "drupal": {
             "type": "composer",
             "url": "https://drupal:drupal@packages.staging.devdrupal.org/8",
+            "only": ["drupal/*"],
             "tuf": true
         }
     },


### PR DESCRIPTION
An idea to get around https://github.com/composer/composer/issues/11704 for testing purposes. 

@phenaproxima  is trying to solve the memory issue in https://github.com/php-tuf/composer-integration/pull/91
While this is not permanent solution, it might be something to try to make sure this is not causing additional problems